### PR TITLE
Avoid payload copy in put methods

### DIFF
--- a/examples/native.js
+++ b/examples/native.js
@@ -1,7 +1,7 @@
 import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 import native from 'k6/x/neofs/native';
 
-const payload = new Uint8Array(open('../go.sum', 'b'));
+const payload = open('../go.sum', 'b');
 const container = "AjSxSNNXbJUDPqqKYm1VbFVDGCakbpUNH8aGjPmGAH3B"
 const neofs_cli = native.connect("s01.neofs.devenv:8080", "")
 

--- a/examples/s3.js
+++ b/examples/s3.js
@@ -1,7 +1,7 @@
 import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 import s3 from 'k6/x/neofs/s3';
 
-const payload = new Uint8Array(open('../go.sum', 'b'));
+const payload = open('../go.sum', 'b');
 const bucket = "cats"
 const s3_cli = s3.connect("http://s3.neofs.devenv:8080")
 

--- a/internal/native/client.go
+++ b/internal/native/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"time"
 
+	"github.com/dop251/goja"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
@@ -37,8 +38,8 @@ type (
 	}
 )
 
-func (c *Client) Put(inputContainerID string, headers map[string]string, payload []byte) PutResponse {
-	rdr := bytes.NewReader(payload)
+func (c *Client) Put(inputContainerID string, headers map[string]string, payload goja.ArrayBuffer) PutResponse {
+	rdr := bytes.NewReader(payload.Bytes())
 	sz := rdr.Size()
 
 	// preparation stage

--- a/internal/s3/client.go
+++ b/internal/s3/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/dop251/goja"
 	"github.com/nspcc-dev/xk6-neofs/internal/stats"
 	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/metrics"
@@ -29,8 +30,8 @@ type (
 	}
 )
 
-func (c *Client) Put(bucket, key string, payload []byte) PutResponse {
-	rdr := bytes.NewReader(payload)
+func (c *Client) Put(bucket, key string, payload goja.ArrayBuffer) PutResponse {
+	rdr := bytes.NewReader(payload.Bytes())
 	sz := rdr.Size()
 
 	stats.Report(c.vu, objPutTotal, 1)


### PR DESCRIPTION
With goja.ArrayBuffer type VU won't perform copy operation during every put invocation.

Inspired by [body payload passing](https://github.com/grafana/k6/blob/5f16f6d1feab6e3d9b6f3f7c856a8a7b1781c5a7/js/modules/k6/http/request.go#L220-L244) in native k6 http module.