### PR TITLE
Configure buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ const neofs_cli = native.connect("s01.neofs.devenv:8080", "")
 ```
 
 #### Methods
+- `setBufferSize(size)`. Sets internal buffer size for data upload and 
+  download. Default is 64 KiB.
 - `put(container_id, headers, payload)`. Returns dictionary with `success` 
   boolean flag, `object_id` string, and `error` string.
 - `get(container_id, object_id)`. Returns dictionary with `success` boolean

--- a/internal/native/native.go
+++ b/internal/native/native.go
@@ -116,9 +116,10 @@ func (n *Native) Connect(endpoint, wif string) (*Client, error) {
 	objGetDuration, _ = registry.NewMetric("neofs_obj_get_duration", metrics.Trend, metrics.Time)
 
 	return &Client{
-		vu:  n.vu,
-		key: pk.PrivateKey,
-		tok: tok,
-		cli: &cli,
+		vu:      n.vu,
+		key:     pk.PrivateKey,
+		tok:     tok,
+		cli:     &cli,
+		bufsize: defaultBufferSize,
 	}, nil
 }


### PR DESCRIPTION
Closes #3 Default value is increased up to 64 KiB.

```js
const neofs_cli = native.connect("s01.neofs.devenv:8080", "")
neofs_cli.setBufferSize(500000)
```

Throws panic on invalid values.