### PR TITLE
[#21] Improve iteration logic in  obj selector

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
+          args: --timeout=2m
 
   tests:
     name: Tests


### PR DESCRIPTION
1. Implement reset method that allows to start iteration from beginning of the registry. This allows to revisit objects in scenarios like object deletion.
2. Add filter structure that allows to select objects based on age.
