### PR TITLE
Use separate sleep intervals for VUs

### DIFF
--- a/scenarios/grpc.js
+++ b/scenarios/grpc.js
@@ -99,8 +99,8 @@ export function teardown(data) {
 }
 
 export function obj_write() {
-    if (__ENV.SLEEP) {
-        sleep(__ENV.SLEEP);
+    if (__ENV.SLEEP_WRITE) {
+        sleep(__ENV.SLEEP_WRITE);
     }
 
     const headers = {
@@ -121,8 +121,8 @@ export function obj_write() {
 }
 
 export function obj_read() {
-    if (__ENV.SLEEP) {
-        sleep(__ENV.SLEEP);
+    if (__ENV.SLEEP_READ) {
+        sleep(__ENV.SLEEP_READ);
     }
 
     const obj = obj_list[Math.floor(Math.random() * obj_list.length)];
@@ -133,8 +133,8 @@ export function obj_read() {
 }
 
 export function obj_delete() {
-    if (__ENV.SLEEP) {
-        sleep(__ENV.SLEEP);
+    if (__ENV.SLEEP_DELETE) {
+        sleep(__ENV.SLEEP_DELETE);
     }
 
     const obj = obj_to_delete_selector.nextObject();

--- a/scenarios/http.js
+++ b/scenarios/http.js
@@ -72,8 +72,8 @@ export function teardown(data) {
 }
 
 export function obj_write() {
-    if (__ENV.SLEEP) {
-        sleep(__ENV.SLEEP);
+    if (__ENV.SLEEP_WRITE) {
+        sleep(__ENV.SLEEP_WRITE);
     }
 
     const container = container_list[Math.floor(Math.random() * container_list.length)];
@@ -96,8 +96,8 @@ export function obj_write() {
 }
 
 export function obj_read() {
-    if (__ENV.SLEEP) {
-        sleep(__ENV.SLEEP);
+    if (__ENV.SLEEP_READ) {
+        sleep(__ENV.SLEEP_READ);
     }
 
     const obj = obj_list[Math.floor(Math.random() * obj_list.length)];

--- a/scenarios/run_scenarios.md
+++ b/scenarios/run_scenarios.md
@@ -11,7 +11,8 @@ Scenarios `grpc.js`, `http.js` and `s3.js` support the following options:
   * `REGISTRY_FILE` - if set, all produced objects will be stored in database for subsequent verification. Database file name will be set to the value of `REGISTRY_FILE`.
   * `WRITE_OBJ_SIZE` - object size in kb for write(PUT) operations.
   * `PREGEN_JSON` - path to json file with pre-generated containers and objects (in case of http scenario we use json pre-generated for grpc scenario).
-  * `SLEEP` - time interval (in seconds) between VU iterations.
+  * `SLEEP_WRITE` - time interval (in seconds) between writing VU iterations.
+  * `SLEEP_READ` - time interval (in seconds) between reading VU iterations.
 
 Examples of how to use these options are provided below for each scenario.
 
@@ -35,6 +36,7 @@ Options (in addition to the common options):
   * `GRPC_ENDPOINTS` - GRPC endpoints of neoFS in format `host:port`. To specify multiple endpoints separate them by comma.
   * `DELETERS` - number of VUs performing delete operations (using deleters requires that options `DELETE_AGE` and `REGISTRY_FILE` are specified as well).
   * `DELETE_AGE` - age of object in seconds before which it can not be deleted. This parameter can be used to control how many objects we have in the system under load.
+  * `SLEEP_DELETE` - time interval (in seconds) between deleting VU iterations.
 
 ## HTTP
 
@@ -90,6 +92,7 @@ Options (in addition to the common options):
   * `S3_ENDPOINTS` - endpoints of S3 gateways in format `host:port`. To specify multiple endpoints separate them by comma.
   * `DELETERS` - number of VUs performing delete operations (using deleters requires that options `DELETE_AGE` and `REGISTRY_FILE` are specified as well).
   * `DELETE_AGE` - age of object in seconds before which it can not be deleted. This parameter can be used to control how many objects we have in the system under load.
+  * `SLEEP_DELETE` - time interval (in seconds) between deleting VU iterations.
   * `OBJ_NAME` - if specified, this name will be used for all write operations instead of random generation.
 
 ## Verify

--- a/scenarios/s3.js
+++ b/scenarios/s3.js
@@ -98,8 +98,8 @@ export function teardown(data) {
 }
 
 export function obj_write() {
-    if (__ENV.SLEEP) {
-        sleep(__ENV.SLEEP);
+    if (__ENV.SLEEP_WRITE) {
+        sleep(__ENV.SLEEP_WRITE);
     }
 
     const key = __ENV.OBJ_NAME || uuidv4();
@@ -118,8 +118,8 @@ export function obj_write() {
 }
 
 export function obj_read() {
-    if (__ENV.SLEEP) {
-        sleep(__ENV.SLEEP);
+    if (__ENV.SLEEP_READ) {
+        sleep(__ENV.SLEEP_READ);
     }
 
     const obj = obj_list[Math.floor(Math.random() * obj_list.length)];
@@ -131,8 +131,8 @@ export function obj_read() {
 }
 
 export function obj_delete() {
-    if (__ENV.SLEEP) {
-        sleep(__ENV.SLEEP);
+    if (__ENV.SLEEP_DELETE) {
+        sleep(__ENV.SLEEP_DELETE);
     }
 
     const obj = obj_to_delete_selector.nextObject();


### PR DESCRIPTION
To fine-tune read/write/delete load we need to have separate sleep intervales for readers/writers/deleters.

The changes were originally authored by anatoly@nspcc.ru <anatoly@nspcc.ru>
