### PR TITLE
[#44] Add params to disable tls check on s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ import s3 from 'k6/x/neofs/s3';
 const s3_cli = s3.connect("http://s3.neofs.devenv:8080")
 ```
 
+You can also provide additional options:
+```js
+import s3 from 'k6/x/neofs/s3';
+const s3_cli = s3.connect("http://s3.neofs.devenv:8080", {'no_verify_ssl': 'true', 'timeout': '60s'})
+```
+
+* `no_verify_ss` - Bool. If `true` - skip verifying the s3 certificate chain and host name (useful if s3 uses self-signed certificates)
+* `timeout` - Duration. Set timeout for requests (in http client). If omitted or zero - timeout is infinite.
+
 ### Methods
 - `createBucket(bucket, params)`. Returns dictionary with `success` boolean flag
   and `error` string. The `params` is a dictionary (e.g. `{acl:'private',lock_enabled:'true',location_constraint:'ru'}`)

--- a/examples/s3.js
+++ b/examples/s3.js
@@ -4,7 +4,7 @@ import s3 from 'k6/x/neofs/s3';
 
 const payload = open('../go.sum', 'b');
 const bucket = "cats"
-const s3_cli = s3.connect("http://s3.neofs.devenv:8080")
+const s3_cli = s3.connect("https://s3.neofs.devenv:8080", {'no_verify_ssl': 'true'})
 
 export const options = {
     stages: [

--- a/internal/s3/s3.go
+++ b/internal/s3/s3.go
@@ -1,7 +1,11 @@
 package s3
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -46,7 +50,7 @@ func (s *S3) Exports() modules.Exports {
 	return modules.Exports{Default: s}
 }
 
-func (s *S3) Connect(endpoint string) (*Client, error) {
+func (s *S3) Connect(endpoint string, params map[string]string) (*Client, error) {
 	resolver := aws.EndpointResolverWithOptionsFunc(func(_, _ string, _ ...interface{}) (aws.Endpoint, error) {
 		return aws.Endpoint{
 			URL: endpoint,
@@ -58,11 +62,34 @@ func (s *S3) Connect(endpoint string) (*Client, error) {
 		return nil, fmt.Errorf("configuration error: %w", err)
 	}
 
+	var noVerifySSL bool
+	if noVerifySSLStr, ok := params["no_verify_ssl"]; ok {
+		if noVerifySSL, err = strconv.ParseBool(noVerifySSLStr); err != nil {
+			return nil, fmt.Errorf("invalid value for 'no_verify_ssl': '%s'", noVerifySSLStr)
+		}
+	}
+
+	var timeout time.Duration
+	if timeoutStr, ok := params["timeout"]; ok {
+		if timeout, err = time.ParseDuration(timeoutStr); err != nil {
+			return nil, fmt.Errorf("invalid value for 'timeout': '%s'", timeoutStr)
+		}
+	}
+
 	cli := s3.NewFromConfig(cfg, func(options *s3.Options) {
 		// use 'domain/bucket/key' instead of default 'bucket.domain/key' scheme
 		options.UsePathStyle = true
 		// do not retry failed requests, by default client does up to 3 retry
 		options.Retryer = aws.NopRetryer{}
+		// s3 sometimes use self-signed certs
+		options.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: noVerifySSL,
+				},
+			},
+			Timeout: timeout,
+		}
 	})
 
 	// register metrics


### PR DESCRIPTION
We can omit the second params. It will also work:
```js
const s3_cli = s3.connect("http://127.0.0.1:8084")
const s3_cli2 = s3.connect("https://127.0.0.1:8085", {'no_verifyssl': 'true'})
```

close #44 
Signed-off-by: Denis Kirillov <denis@nspcc.ru>