### PR TITLE
workflows: build darwin/arm64 binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ${{matrix.os.name}}
     strategy:
       matrix:
-        os: [ { name: ubuntu-20.04, bin-name: linux }, { name: macos-14, bin-name: darwin } ]
+        os: [ { name: ubuntu-24.04, bin-name: linux }, { name: macos-14, bin-name: darwin } ]
         arch: [ amd64, arm64 ]
         exclude:
-          - os: { name: ubuntu-20.04, bin-name: linux }
+          - os: { name: ubuntu-24.04, bin-name: linux }
             arch: 'arm64'
           - os: { name: macos-14, bin-name: darwin }
             arch: 'amd64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,13 @@ jobs:
     runs-on: ${{matrix.os.name}}
     strategy:
       matrix:
-        os: [ { name: ubuntu-20.04, bin-name: linux } ]
-        arch: [ amd64 ]
+        os: [ { name: ubuntu-20.04, bin-name: linux }, { name: macos-14, bin-name: darwin } ]
+        arch: [ amd64, arm64 ]
+        exclude:
+          - os: { name: ubuntu-20.04, bin-name: linux }
+            arch: 'arm64'
+          - os: { name: macos-14, bin-name: darwin }
+            arch: 'amd64'
 
     steps:
       - name: Check out code


### PR DESCRIPTION
We have tests that need them on darwin-arm64, so let's build these binaries by default to avoid rebuilding them during test runs.

See https://github.com/nspcc-dev/neofs-node/pull/2919/files#r1722260173