### PR TITLE
Go 1.22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: true
 
       - name: Update Go modules

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,24 +34,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
-        go: [ '1.21', '1.22' ]
+        go: [ '1.22', '1.23' ]
         exclude:
           # Only latest Go version for Windows and MacOS.
           - os: windows-2022
-            go: '1.21'
-          - os: windows-2022
             go: '1.22'
           - os: macos-12
-            go: '1.21'
-          - os: macos-12
             go: '1.22'
-          - os: macos-14
-            go: '1.21'
           - os: macos-14
             go: '1.22'
           # Exclude latest Go version for Ubuntu as Coverage uses it.
           - os: ubuntu-22.04
-            go: '1.22'
+            go: '1.23'
       fail-fast: false
     steps:
       - name: Setup go
@@ -81,7 +75,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           cache: true
-          go-version: 1.22
+          go-version: 1.23
 
       - name: Test and write coverage profile
         run: go test -coverprofile=coverage.txt -covermode=atomic ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nspcc-dev/xk6-neofs
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.3

--- a/internal/datagen/generator_test.go
+++ b/internal/datagen/generator_test.go
@@ -46,7 +46,7 @@ func TestGenerator(t *testing.T) {
 	t.Run("keeps generating slices after consuming entire tail", func(t *testing.T) {
 		g := NewGenerator(vu, 1000)
 		initialSlice := g.nextSlice()
-		for i := 0; i < TailSize; i++ {
+		for range TailSize {
 			g.nextSlice()
 		}
 		// After we looped around our tail and returned to the beginning we should have a


### PR DESCRIPTION
Closes #75.

There is in `internal/generator.go` in func `nextSlice` use `rand.Read`. The error has not been handled before. What is the best thing to do now?