### PR TITLE
workflows: drop macos-12 runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,13 +19,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
+        os: [ubuntu-22.04, windows-2022, macos-14]
         go: [ '1.22', '1.23' ]
         exclude:
           # Only latest Go version for Windows and MacOS.
           - os: windows-2022
-            go: '1.22'
-          - os: macos-12
             go: '1.22'
           - os: macos-14
             go: '1.22'


### PR DESCRIPTION
GitHub will soon remove it completely: https://github.com/actions/runner-images/issues/10721